### PR TITLE
Expose UIWebView from JSEditor

### DIFF
--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -100,7 +100,14 @@ class ResourceFrame extends ScriptWidget {
 
         if (ext == ".js" || ext == ".txt" || ext == ".json" || ext == ".ts") {
 
-            editor = new Editor.JSResourceEditor(path, this.tabcontainer);
+             let jseditor = new Editor.JSResourceEditor(path, this.tabcontainer);
+
+             jseditor.subscribeToEvent(EditorEvents.UserPreferencesChangedNotification, (data) => {
+                 // We can get the webclient here now, though this might not be a great place to set this up                 
+                 let webClient = jseditor.webView.webClient;
+             });
+
+             editor = jseditor;
 
         } else if (ext == ".scene") {
 

--- a/Script/Packages/Editor/Editor.json
+++ b/Script/Packages/Editor/Editor.json
@@ -1,6 +1,6 @@
 {
 	"name" : "Editor",
-	"includes" : ["<Atomic/Graphics/DebugRenderer.h>"],
+	"includes" : ["<Atomic/Graphics/DebugRenderer.h>", "<AtomicWebView/UIWebView.h>"],
 	"sources" : ["Source/AtomicEditor/Application", "Source/AtomicEditor/Utils",
 							 "Source/AtomicEditor/EditorMode", "Source/AtomicEditor/PlayerMode",
 							 "Source/AtomicEditor/Editors", "Source/AtomicEditor/Editors/SceneEditor3D",

--- a/Script/Packages/Editor/Package.json
+++ b/Script/Packages/Editor/Package.json
@@ -2,7 +2,7 @@
 {
   "name" : "Editor",
   "namespace" : "AtomicEditor",
-  "dependencies" : ["Script/Packages/Atomic"],
+  "dependencies" : ["Script/Packages/WebView"],
   "modules" : ["Editor"],
   "platforms" : ["WINDOWS", "MACOSX", "LINUX"]
 }

--- a/Source/AtomicEditor/Editors/JSResourceEditor.h
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.h
@@ -47,6 +47,9 @@ public:
 
     virtual ~JSResourceEditor();
 
+    /// Get the editor's UIWebView
+    UIWebView* GetWebView() const { return webView_; }
+
     bool OnEvent(const TBWidgetEvent &ev);
 
     bool FindText(const String& findText, unsigned flags);
@@ -60,7 +63,7 @@ public:
     void SetFocus();
 
     bool Save();
-    
+
 private:
 
     void HandleWebViewLoadEnd(StringHash eventType, VariantMap& eventData);


### PR DESCRIPTION
This PR will make the UIWebView and thus the WebClient accessible to script.  The trick is that each module can specify a single dependency (though dependencies are loaded recursively).  So, now Editor -> AtomicWebView -> Atomic.  It will be pretty easy to do basic dependency tracking between modules, however until them if a module loads a dependency more than once, it'll result in name collisions.

I added a little example event handler, though we really do need to refactor the resource frame type handling.  If you have thoughts on this cool, otherwise I can follow up with replacing the native handler in the ResourceFrame.ts and add a note about refactoring.
